### PR TITLE
usb/device-info: Listen for USB device add and remove events.

### DIFF
--- a/samples/usb/device-info/manifest.json
+++ b/samples/usb/device-info/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "USB Device Info",
-  "version": "0.3",
+  "version": "0.4",
   "description": "This application displays detailed technical information about USB devices that are connected to your computer.",
   "manifest_version": 2,
   "minimum_chrome_version": "40.0.2202.3",

--- a/samples/usb/device-info/script.js
+++ b/samples/usb/device-info/script.js
@@ -82,7 +82,7 @@ function deviceSelectionChanged() {
     el.textContent = 'No device selected.';
     device_info.appendChild(el);
   } else {
-    var device = devices[device_selector.options.item(index).value].device;
+    var device = devices[device_selector.options.item(index).value];
 
     appendDeviceInfo(
         'Product ID',
@@ -114,14 +114,30 @@ chrome.usb.getDevices({}, function(found_devices) {
   }
 
   for (var device of found_devices) {
-    var deviceInfo = {
-      'device': device,
-      'index': device_selector.options.length
-    };
-    devices[device.device] = deviceInfo;
+    devices[device.device] = device;
     appendToDeviceSelector(device);
   }
 });
+
+if (chrome.usb.onDeviceAdded) {
+  chrome.usb.onDeviceAdded.addListener(function (device) {
+    devices[device.device] = device;
+    appendToDeviceSelector(device);
+  });
+}
+
+if (chrome.usb.onDeviceRemoved) {
+  chrome.usb.onDeviceRemoved.addListener(function (device) {
+    delete devices[device.device];
+    for (var i = 0; i < device_selector.length; ++i) {
+      if (device_selector.options.item(i).value == device.device) {
+        device_selector.remove(i);
+        deviceSelectionChanged();
+        break;
+      }
+    }
+  });
+}
 
 add_device.addEventListener('click', function() {
   chrome.usb.getUserSelectedDevices({
@@ -136,13 +152,17 @@ add_device.addEventListener('click', function() {
     for (var device of selected_devices) {
       var deviceInfo = { 'device': device, 'index': undefined };
       if (device.device in devices) {
-        deviceInfo = devices[device.device];
+        for (var i = 0; i < device_selector.length; ++i) {
+          if (device_selector.options.item(i).value == device.device) {
+            device_selector.selectedIndex = i;
+            break;
+          }
+        }
       } else {
-        deviceInfo.index = device_selector.options.length;
-        devices[device.device] = deviceInfo;
+        devices[device.device] = device;
         appendToDeviceSelector(device);
+        device_selector.selectedIndex = device_selector.options.length - 1;
       }
-      device_selector.selectedIndex = deviceInfo.index;
       deviceSelectionChanged();
     }
   });


### PR DESCRIPTION
This patch is an example of using the chrome.usb.onDeviceAdded and
chrome.usb.onDeviceRemoved events to maintain a list of connected
devices.