### PR TITLE
[usb-device-info] Remove deprecated chrome.usb.requestAccess

### DIFF
--- a/samples/usb/device-info/manifest.json
+++ b/samples/usb/device-info/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "USB Device Info",
-  "version": "0.3",
+  "version": "0.4",
   "description": "This application displays detailed technical information about USB devices that are connected to your computer.",
   "manifest_version": 2,
   "minimum_chrome_version": "40.0.2202.3",

--- a/samples/usb/device-info/manifest.json
+++ b/samples/usb/device-info/manifest.json
@@ -3,7 +3,7 @@
   "version": "0.4",
   "description": "This application displays detailed technical information about USB devices that are connected to your computer.",
   "manifest_version": 2,
-  "minimum_chrome_version": "40.0.2202.3",
+  "minimum_chrome_version": "40.0.2213.0",
   "app": {
     "background": {
       "scripts": ["background.js"]

--- a/samples/usb/device-info/script.js
+++ b/samples/usb/device-info/script.js
@@ -59,20 +59,6 @@ function populateDeviceInfo(handle, callback) {
   });
 }
 
-function openDevice(device, callback) {
-  if (window.navigator.appVersion.indexOf('; CrOS ') != -1) {
-    chrome.usb.requestAccess(device, -1, function () {
-      if (chrome.runtime.lastError != undefined) {
-        callback();
-      } else {
-        chrome.usb.openDevice(device, callback);
-      }
-    });
-  } else {
-    chrome.usb.openDevice(device, callback);
-  }
-}
-
 function deviceSelectionChanged() {
   device_info.innerHTML = "";
 
@@ -91,7 +77,7 @@ function deviceSelectionChanged() {
         'Vendor ID',
         '0x' + ('0000' + device.vendorId.toString(16)).slice(-4));
 
-    openDevice(device, function(handle) {
+    chrome.usb.openDevice(device, function(handle) {
       if (chrome.runtime.lastError != undefined) {
         var el = document.createElement('em');
         el.textContent = 'Failed to open device: ' +


### PR DESCRIPTION
According to https://developer.chrome.com/apps/usb#method-requestAccess, we should remove it from the usb-device-info sample.

TBR=@reillyeon