### PR TITLE
[device-info-demo] Handle onDeviceAdded and onDeviceRemoved events

### DIFF
--- a/samples/bluetooth-samples/device-info-demo/manifest.json
+++ b/samples/bluetooth-samples/device-info-demo/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Device Information Service Demo",
   "description": "Device Information Demo using chrome.bluetoothLowEnergy",
-  "version": "0.2",
+  "version": "0.3",
   "minimum_chrome_version": "37",
   "icons": {
     "16": "bluetooth.png",

--- a/samples/bluetooth-samples/device-info-demo/ui.js
+++ b/samples/bluetooth-samples/device-info-demo/ui.js
@@ -88,6 +88,17 @@ var UI = (function() {
     };
   };
 
+  UI.prototype.triggerDeviceSelection = function() {
+    var deviceSelector = document.getElementById('device-selector');
+    if (deviceSelector.onchange)
+      deviceSelector.onchange();
+  };
+
+  UI.prototype.getSelectedDeviceAddress = function() {
+    var deviceSelector = document.getElementById('device-selector');
+    return deviceSelector[deviceSelector.selectedIndex].value;
+  };
+
   UI.prototype.updateDeviceSelector = function(deviceMap, reset) {
     var deviceSelector = document.getElementById('device-selector');
     var placeHolder = document.getElementById('placeholder');


### PR DESCRIPTION
Similar to the battery-service-demo bluetooth sample, the device-info-demo bluetooth sample needs to handle `onDeviceAdded` and `onDeviceRemoved` events to get notified about new discovered devices.

BUG=#350
TBR=@scheib
