### PR TITLE
Add color to window options

### DIFF
--- a/samples/window-options/manifest.json
+++ b/samples/window-options/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Window Options Sample",
-  "version": "1",
+  "version": "2",
   "minimum_chrome_version": "35",
   "icons": {
     "128": "icon_128.png"

--- a/samples/window-options/window.html
+++ b/samples/window-options/window.html
@@ -161,6 +161,13 @@
                 </td>
               </tr>
               <tr>
+                <td>Color, Inactive Color:</td>
+                <td>
+                  <input type="text" class="size" id="newWindowColor" placeholder="#000000" />
+                  <input type="text" class="size" id="newWindowInactiveColor" placeholder="#000000" />
+                </td>
+              </tr>
+              <tr>
                 <td>Visibility:</td>
                 <td>
                   <label><input type="radio" name="newWindowHidden" value="visible" checked />Visible</label>

--- a/samples/window-options/window.js
+++ b/samples/window-options/window.js
@@ -72,6 +72,16 @@ function createNewWindow() {
   optionsDictionary.alwaysOnTop = $('#newWindowOnTop').is(':checked');
   optionsDictionary.focused = $('#newWindowFocused').is(':checked');
 
+  if (optionsDictionary.frame === 'chrome') {
+    optionsDictionary.frame = { type: 'chrome' };
+    if ($('#newWindowColor').val()) {
+      optionsDictionary.frame.color = $('#newWindowColor').val();
+    }
+    if ($('#newWindowInactiveColor').val()) {
+      optionsDictionary.frame.inactiveColor = $('#newWindowInactiveColor').val();
+    }
+  }
+
   if (optionsDictionary.hidden) {
     callback = function (win) {
       setTimeout(function () { win.show(); }, kHiddenWindowDelay);


### PR DESCRIPTION
Here's an example of `activeColor` and `inactiveColor` for the Window Options sample

![screenshot 2015-02-09 at 10 10 53 am](https://cloud.githubusercontent.com/assets/634478/6103387/fb019b38-b043-11e4-877f-dbfab297b56c.png)

BUG=#335
TBR=@scheib