### PR TITLE
Removed deprecated chrome.app.window.{resizeTo,moveTo} 

### DIFF
--- a/samples/io2012-presentation/js/main.js
+++ b/samples/io2012-presentation/js/main.js
@@ -41,17 +41,22 @@ var windowingApiDemo = {
   launch: function() {
     windowingApiDemo.clear();
     chrome.app.window.create('windowing_api/original.html', {
-      top: 128,
-      left: 128,
-      width: 256,
-      height: 256
+      outerBounds: {
+        top: 128,
+        left: 128,
+        width: 256,
+        height: 256
+      }
     }, function(originalWindow) {
+
       windowingApiDemo.windows.push(originalWindow);
       chrome.app.window.create('windowing_api/copycat.html', {
-        top: 128,
-        left: 384 + 5,
-        width: 256,
-        height: 256,
+        outerBounds: {
+          top: 128,
+          left: 384 + 5,
+          width: 256,
+          height: 256,
+        },
         frame: 'none'
       }, function(copycatWindow) {
         windowingApiDemo.windows.push(copycatWindow);
@@ -62,12 +67,11 @@ var windowingApiDemo = {
             return;
           }
 
-          copycatWindow.moveTo(
-              originalWindow.contentWindow.screenX + originalWindow.contentWindow.outerWidth + 5,
-              originalWindow.contentWindow.screenY);
-          copycatWindow.resizeTo(
-              originalWindow.contentWindow.outerWidth,
-              originalWindow.contentWindow.outerHeight);
+          copycatWindow.outerBounds.left = originalWindow.contentWindow.screenX + originalWindow.contentWindow.outerWidth + 5;
+          copycatWindow.outerBounds.top = originalWindow.contentWindow.screenY;
+          copycatWindow.outerBounds.width = originalWindow.contentWindow.outerWidth;
+          copycatWindow.outerBounds.height = originalWindow.contentWindow.outerHeight;
+
         }, 10);
 
         originalWindow.focus();

--- a/samples/usb-label-printer/index.js
+++ b/samples/usb-label-printer/index.js
@@ -331,6 +331,7 @@ function ditherImg(imgData) {
 
 
   var updateCanvasSize = function(e) {
+    var curWindow = chrome.app.window.current();
     var canvas = $("previewCanvas");
     pageHeight = parseInt($('pageWidth').value, 10);
     pageWidth = parseInt($('pageHeight').value, 10);
@@ -342,7 +343,9 @@ function ditherImg(imgData) {
     canvas.set('width', pageHeight);
     canvas.set('height', pageWidth);
     updateCanvas();
-    chrome.app.window.current().resizeTo(Math.max(1030, pageHeight + 130), pageWidth + 400);
+
+    curWindow.outerBounds.width = Math.max(1030, pageHeight + 130);
+    curWindow.outerBounds.height = pageWidth + 400;
   };
 
 

--- a/samples/usb-label-printer/index.js
+++ b/samples/usb-label-printer/index.js
@@ -340,8 +340,8 @@ function ditherImg(imgData) {
     }
     $('pageWidth').value=pageHeight;
     $('pageHeight').value=pageWidth;
-    canvas.set('width', pageHeight);
-    canvas.set('height', pageWidth);
+    canvas.setAttribute('width', pageHeight);
+    canvas.setAttribute('height', pageWidth);
     updateCanvas();
 
     curWindow.outerBounds.width = Math.max(1030, pageHeight + 130);

--- a/samples/window-state/window.js
+++ b/samples/window-state/window.js
@@ -142,7 +142,9 @@ $('#move').onclick = function(e) {
   var y = parseInt($('#moveWindowTop').value);
   setTimeout(
     function() {
-      chrome.app.window.current().moveTo(x, y);
+      var curWindow = chrome.app.window.current();
+      curWindow.outerBounds.left = x;
+      curWindow.outerBounds.top = y;
     },
     $('#delay-slider').value);
 };
@@ -152,7 +154,9 @@ $('#resize').onclick = function(e) {
   var h = parseInt($('#resizeWindowHeight').value);
   setTimeout(
     function() {
-      chrome.app.window.current().resizeTo(w, h);
+      var curWindow = chrome.app.window.current();
+      curWindow.outerBounds.width = w;
+      curWindow.outerBounds.height = h;
     },
     $('#delay-slider').value);
 };


### PR DESCRIPTION
- All references have been replaced with chrome.app.window.outerBounds. This should resolve GoogleChrome/chrome-app-samples#369

- usb-label-printer/index.js was trying to resize the canvas using 'set' method. I believe this was meant to be a call to 'setAttribute' instead.