### PR TITLE
[hid] Add onDeviceAdded and onDeviceRemoved events

### DIFF
--- a/samples/hid/manifest.json
+++ b/samples/hid/manifest.json
@@ -2,7 +2,7 @@
 	"name": "HID Sample App",
 	"manifest_version": 2,
 	"version": "0.3.1",
-  "minimum_chrome_version": "36.0.1941.0",
+  "minimum_chrome_version": "41",
 	"app": {
 		"background": {
 			"scripts": [ "main.js" ]


### PR DESCRIPTION
Hey @reillyeon,

Before adding `chrome.hid.getUserSelectedDevices`, I thought it was better to add `onDeviceAdded` and `onDeviceRemoved` event listeners to the `hid` sample instead of polling.

BUG=#396