### PR TITLE
Fixed Title not Showing up on Browser Tabs

### DIFF
--- a/samples/webview-samples/multi-tab-browser/browser.css
+++ b/samples/webview-samples/multi-tab-browser/browser.css
@@ -459,6 +459,12 @@ webview {
 .req-exit-button {
   color: rgb(193, 193, 193);
   background: rgb(90, 90, 90);
+  width: 40px;
+  text-align: center;
+}
+
+.req-exit-button:focus {
+  border: 1px solid #fff;
 }
 
 #permission-box {

--- a/samples/webview-samples/multi-tab-browser/browser.html
+++ b/samples/webview-samples/multi-tab-browser/browser.html
@@ -62,8 +62,8 @@
   <div id="exit-box">
     <h2> Browser Exit? </h2>
     <h3> Do you really want to exit browser? </h3>
-    <button id="exit-yes" class="req-exit-button"> Yes </button>
-    <button id="exit-no" class="req-exit-button"> No </button>
+    <button id="exit-yes" class="req-exit-button" tabindex="2"> Yes </button>
+    <button id="exit-no" class="req-exit-button" tabindex="4"> No </button>
   </div>
 
   <div id="permission-box">

--- a/samples/webview-samples/multi-tab-browser/config.js
+++ b/samples/webview-samples/multi-tab-browser/config.js
@@ -1,6 +1,6 @@
 // Global configuration variables
 var config = {
-  'homepage': 'http://www.google.com/',
+  'homepage': 'http://www.google.com',
   'popupConfirmBox': {
     'innerHTML': 'This webpage would like to open a window at <span class="popup-url"></span> Would you like to allow this popup? <a href="#popup-allow" class="popup-allow">Allow</a> <a href="#popup-deny" class="popup-deny">Deny</a>',
     'urlSpanClass': 'popup-url',

--- a/samples/webview-samples/multi-tab-browser/config.js
+++ b/samples/webview-samples/multi-tab-browser/config.js
@@ -1,6 +1,6 @@
 // Global configuration variables
 var config = {
-  'homepage': 'http://www.google.com',
+  'homepage': 'https://www.google.com',
   'popupConfirmBox': {
     'innerHTML': 'This webpage would like to open a window at <span class="popup-url"></span> Would you like to allow this popup? <a href="#popup-allow" class="popup-allow">Allow</a> <a href="#popup-deny" class="popup-deny">Deny</a>',
     'urlSpanClass': 'popup-url',

--- a/samples/webview-samples/multi-tab-browser/exit_box_controller.js
+++ b/samples/webview-samples/multi-tab-browser/exit_box_controller.js
@@ -10,6 +10,7 @@ var exitTool = (function() {
     controller = this;
     yes = query('#exit-yes');
     no = query('#exit-no');
+    var curr_focus = 'no';
     yes.onclick = function() {
       window.close();
     };
@@ -17,16 +18,31 @@ var exitTool = (function() {
     this.overlay = document.createElement('div');
     this.overlay.className = 'overlay-gray';
     document.body.appendChild(this.overlay);
+    containerElement.onkeydown = function(e) {
+      e.preventDefault();
+      if (e.keyCode === 9 && containerElement.style.display !== 'none') {
+        if (curr_focus === 'no') {
+          curr_focus = 'yes';
+          yes.focus();
+        } else {
+          curr_focus = 'no';
+          no.focus();
+        }
+      }
+    };
   };
 
   ExitController.prototype.activate = function() {
     containerElement.style.display = 'block';
     this.overlay.style.display = 'block';
+    no.focus();
   };
 
   function deactivate() {
     containerElement.style.display = 'none';
     controller.overlay.style.display = 'none';
+    yes.tabIndex = -1;
+    no.tabIndex = -1;
   }
 
   return {'ExitController': ExitController};

--- a/samples/webview-samples/multi-tab-browser/exit_box_controller.js
+++ b/samples/webview-samples/multi-tab-browser/exit_box_controller.js
@@ -19,14 +19,23 @@ var exitTool = (function() {
     this.overlay.className = 'overlay-gray';
     document.body.appendChild(this.overlay);
     containerElement.onkeydown = function(e) {
+      if (containerElement.style.display === 'none') {
+        return;
+      }
       e.preventDefault();
-      if (e.keyCode === 9 && containerElement.style.display !== 'none') {
+      if (e.keyCode === 9) {
         if (curr_focus === 'no') {
           curr_focus = 'yes';
           yes.focus();
         } else {
           curr_focus = 'no';
           no.focus();
+        }
+      } else if (e.keyCode === 13) {
+        if (curr_focus === 'yes') {
+          window.close();
+        } else {
+          deactivate();
         }
       }
     };
@@ -35,6 +44,7 @@ var exitTool = (function() {
   ExitController.prototype.activate = function() {
     containerElement.style.display = 'block';
     this.overlay.style.display = 'block';
+    curr_focus = 'no';
     no.focus();
   };
 

--- a/samples/webview-samples/multi-tab-browser/guest_messaging.js
+++ b/samples/webview-samples/multi-tab-browser/guest_messaging.js
@@ -8,7 +8,7 @@ var webviewTitleInjectionComplete = false;
     var title = null;
     var postTitle = (function() {
       return function(e) {
-        title = document.title;
+        title = document.title;        
         var data = {
           'type': 'titleResponse',
           'tabName': tabName,

--- a/samples/webview-samples/multi-tab-browser/guest_messaging.js
+++ b/samples/webview-samples/multi-tab-browser/guest_messaging.js
@@ -8,7 +8,7 @@ var webviewTitleInjectionComplete = false;
     var title = null;
     var postTitle = (function() {
       return function(e) {
-        title = document.title;        
+        title = document.title;
         var data = {
           'type': 'titleResponse',
           'tabName': tabName,

--- a/samples/webview-samples/multi-tab-browser/tabs.js
+++ b/samples/webview-samples/multi-tab-browser/tabs.js
@@ -150,8 +150,6 @@ var tabs = (function(popupModule, contextMenuModule) {
         webview,
         this.popupConfirmBoxList);
     this.webview = webview;
-    this.scriptInjectionAttempted = false;
-
     this.initLabelContainer();
     this.initWebview();
   };
@@ -190,6 +188,13 @@ var tabs = (function(popupModule, contextMenuModule) {
     this.webview.setAttribute('data-name', this.name);
     this.webviewContainer.setAttribute('data-name', this.name);
     this.webviewContainer.classList.add('webview-container');
+    this.webview.addContentScripts([
+          {
+            'name': 'Messageing',
+            'matches': ['<all_urls>'],
+            'js': { 'files': ['guest_messaging.js']},
+            'run_at': 'document_start'
+          }]);
 
     (function(tab) {
       tab.webview.addEventListener(
@@ -256,7 +261,6 @@ var tabs = (function(popupModule, contextMenuModule) {
     }
 
     this.loading = true;
-    this.scriptInjectionAttempted = false;
     this.url = e.url;
     this.tabList.browser.doTabNavigating(this, e.url);
   };
@@ -268,36 +272,13 @@ var tabs = (function(popupModule, contextMenuModule) {
     this.loading = false;
   };
 
-  Tab.prototype.doContentLoad = function(e) {
-    if (!this.scriptInjectionAttempted) {
-      // Try to inject title-update-messaging script
-      (function(tab) {
-        tab.webview.addContentScripts([
-          {
-            'name': 'Messageing',
-            'matches': ['<all_urls>'],
-            'js': { 'files': ['guest_messaging.js']},
-            'run_at': 'document_end'
-          }]);
-      }(this));
-      this.scriptInjectionAttempted = true;
-    }
-  };
-
-  Tab.prototype.doScriptInjected = function(results) {
-    if (!results || !results.length) {
-      console.warn(
-          'Warning: Failed to inject guest_messaging.js',
-          this.webview);
-    } else {
-      // Send a message to the webview so it can get a reference to
-      // the embedder
-      var data = {
-        'type': 'titleRequest',
-        'tabName': this.name
-      };
-      this.webview.contentWindow.postMessage(JSON.stringify(data), '*');
-    }
+  Tab.prototype.doContentLoad = function(e) {    
+    // TODO: add the code which is to be run after 'contentload' here.
+    var data = {
+      'type': 'titleRequest',
+      'tabName': this.name
+    };
+    this.webview.contentWindow.postMessage(JSON.stringify(data), '*');
   };
 
   // New window triggered by existing window

--- a/samples/webview-samples/multi-tab-browser/tabs.js
+++ b/samples/webview-samples/multi-tab-browser/tabs.js
@@ -190,7 +190,7 @@ var tabs = (function(popupModule, contextMenuModule) {
     this.webviewContainer.classList.add('webview-container');
     this.webview.addContentScripts([
           {
-            'name': 'Messageing',
+            'name': 'Messaging',
             'matches': ['<all_urls>'],
             'js': { 'files': ['guest_messaging.js']},
             'run_at': 'document_start'
@@ -272,8 +272,7 @@ var tabs = (function(popupModule, contextMenuModule) {
     this.loading = false;
   };
 
-  Tab.prototype.doContentLoad = function(e) {    
-    // TODO: add the code which is to be run after 'contentload' here.
+  Tab.prototype.doContentLoad = function(e) {
     var data = {
       'type': 'titleRequest',
       'tabName': this.name


### PR DESCRIPTION
The original implementation of the new-window and user-agent, which are the skeleton for multi-tab browser are based on [\<webview>.executeScript](https://developer.chrome.com/apps/tags/webview#method-executeScript). I initially replaced executeScript with the [less racy API](https://code.google.com/p/chromium/issues/detail?id=489710), [\<webview>.addContentScripts](https://developer.chrome.com/apps/tags/webview#method-addContentScripts). However, the structure of postMessage-ing was not  changed accordingly and hence, the guest (inside the webview) could not communicate with the embedder.

While at this, I also fixed some minor issues with the close dialog which shows up when exiting the last tab. It can now show focused button and also tab + enter keys work.