### PR TITLE
Fix sizing of the find and zoom forms with Chrome M48+

### DIFF
--- a/samples/webview-samples/browser/browser.css
+++ b/samples/webview-samples/browser/browser.css
@@ -101,6 +101,7 @@ compared to the back/forward buttons */
   -webkit-flex: 1;
   display: -webkit-flex;
   -webit-flex-direction: row;
+  min-width: 0;
 }
 
 #zoom-box input,
@@ -116,6 +117,7 @@ compared to the back/forward buttons */
   padding: 2px;
   -webkit-box-sizing: border-box;
   -webkit-flex: 1;
+  min-width: 0;
 }
 
 #zoom-box {


### PR DESCRIPTION
In Chrome 48 and later, (more/all) flex items have an implied minimum width of (essentially) "min-content". Chrome used to have a bug and did not apply that to all flex items; now it does. In this case, this minimum width is undesirable, so adding min-width: 0 here.

Chrome bug https://code.google.com/p/chromium/issues/detail?id=556379
See also https://www.chromestatus.com/feature/5651186401148928