### PR TITLE
Fix canvas sizing when resizing the window

### DIFF
--- a/samples/image-edit/index.html
+++ b/samples/image-edit/index.html
@@ -79,6 +79,8 @@ output {
 }
 canvas {
   -webkit-flex: 1;
+  min-width: 0;
+  min-height: 0;
   border: 1px #aaa solid;
   box-shadow: 0px 2px 10px rgba(0,0,0,0.5) inset;
   background-image: url('assets/work_area_background.png');


### PR DESCRIPTION
This fixes https://bugs.chromium.org/p/chromium/issues/detail?id=567515

When maximizing/unmaximizing the window, the canvas is sized incorrectly due to the wrong min-width.