### PR TITLE
BrowserSample: Ensure the webview is focused.

### DIFF
--- a/samples/webview-samples/browser/browser.js
+++ b/samples/webview-samples/browser/browser.js
@@ -4,6 +4,7 @@ var isLoading = false;
 onload = function() {
   var webview = document.querySelector('webview');
   doLayout();
+  webview.focus();
 
   var version = navigator.appVersion.substr(navigator.appVersion.lastIndexOf('Chrome/') + 7);
   var match = /([0-9]*)\.([0-9]*)\.([0-9]*)\.([0-9]*)/.exec(version);
@@ -196,7 +197,9 @@ onload = function() {
 
 function navigateTo(url) {
   resetExitedState();
-  document.querySelector('webview').src = url;
+  var webview = document.querySelector('webview');
+  webview.focus();
+  webview.src = url;
 }
 
 function doLayout() {

--- a/samples/webview-samples/browser/manifest.json
+++ b/samples/webview-samples/browser/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Browser Sample",
   "minimum_chrome_version": "24.0.1307.0",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "icons": {
     "16": "icon_16.png",
     "128": "icon_128.png"


### PR DESCRIPTION
Like a real web browser, the content should be focused whenever it is
navigated. Additionally, since there is a default web page shown on
start, the webview should be focused. This is unlike a new tab page in
chrome that doesn't really have content and invites the user to type
into the address bar (which should have focus in that case.)